### PR TITLE
feat: More robust workflow

### DIFF
--- a/loong-status/front/src/components/DataTable.vue
+++ b/loong-status/front/src/components/DataTable.vue
@@ -239,6 +239,10 @@ export default {
       } else {
         status += '<span style="color: gray;">🅻</span>';
       }
+
+      if (item.is_blacklisted === true) {
+        status += '<span style="color: black;">🅱︎</span>';
+      }
       // if (flags) {
       //   if (flags & 1) status += `<span><a href="https://github.com/lcpu-club/loongarch-packages/tree/master/${item.base}" style="color: lime;">🅿</a></span>`;
       //   if (flags & 2) status += '<span style="color: blue;">🅲</span>';
@@ -279,6 +283,7 @@ export default {
         Base: item.base,
         Repo: item.repo,
         has_log: item.has_log,
+        is_blacklisted: item.is_blacklisted,
         'x86 Version': mergeVersion(item.x86_version, item.x86_testing_version, item.x86_staging_version),
         'Loong Version': mergeVersion(item.loong_version, item.loong_testing_version, item.loong_staging_version),
         Status: compareAll(item),
@@ -374,7 +379,8 @@ export default {
       { symbol: '🅻', description: 'has build log on server', style: 'color: gold;' },
       { symbol: '🅲', description: 'build with nocheck', style: 'color: blue;' },
       { symbol: '🅾', description: 'config.sub is too old', style: 'color: orange;' },
-      { symbol: '🅵', description: 'build fails', style: 'color: red;' }
+      { symbol: '🅵', description: 'build fails', style: 'color: red;' },
+      { symbol: '🅱︎', description: 'in blacklist', style: 'color: black;' }
       ],
       columnWidths: [
           { width: '20%' },  

--- a/loong-status/front/src/components/DataTable.vue
+++ b/loong-status/front/src/components/DataTable.vue
@@ -110,8 +110,18 @@
         <thead>
           <tr>
             <th v-for="column in columns" :key="column">
-              <div class="column-header">
+              <div class="column-header"
+              @click="column === 'Repo' ? toggleRepoFilter() : null"
+               :class="{ 'clickable': column === 'Repo' }"
+              >
                 {{ column }}
+                <span v-if="column === 'Repo'" class="repo-filter-dropdown" v-show="showRepoFilter">
+                    <ul>
+                      <li @click.stop="filterRepo('')">All</li>
+                    <li @click.stop="filterRepo('extra')">Extra</li>
+                    <li @click.stop="filterRepo('core')">Core</li>
+                    </ul>
+                </span>
                 <!-- Status Legend -->
                 <span v-if="column === 'Status'" class="help-tooltip">
                   [?]
@@ -185,7 +195,9 @@ export default {
     const currentPage = ref(1);
     const searchName = ref('')
     const selectedErrorType = ref('')
-    const selectedStatus = ref('');
+    // const selectedStatus = ref('');
+    const showRepoFilter = ref(false);
+    const selectedRepo = ref('');
     const route = useRoute();
     const showFilter = ref(false);
 
@@ -267,7 +279,8 @@ export default {
             page: currentPage.value,
             per_page: perPage.value,
             name: searchName.value,
-            error_type: selectedErrorType.value
+            error_type: selectedErrorType.value,
+            repo: selectedRepo.value
           },
         });
         tableDataRaw.value = response.data.data;
@@ -314,6 +327,7 @@ export default {
     onMounted(() => {
       searchName.value = route.query.name?.trim() || null;
       selectedErrorType.value = route.query.error_type?.trim() || null;
+      selectedRepo.value = route.query.repo?.trim() || null;
       fetchData();
     });
 
@@ -335,12 +349,23 @@ export default {
       showFilter.value = !showFilter.value
     }
 
+    const toggleRepoFilter = () => {
+      showRepoFilter.value = !showRepoFilter.value;
+    };
+
     const selectFilter = (label) => {
       label = label === 'All failed builds' ? 'Success' : label
       selectedErrorType.value = selectedErrorType.value === label ? null : label
       showFilter.value = false
       fetchData()
     }
+
+    const filterRepo = (repo) => {
+      selectedRepo.value = repo?.trim() || null;
+      showRepoFilter.value = !showRepoFilter.value;
+      fetchData();
+    };
+
     return {
       tableData,
       columns,
@@ -353,11 +378,13 @@ export default {
       nextPage,
       prevPage,
       goToSpecificPage,
-      selectedStatus,
       toggleFilter,
       showFilter,
       selectFilter,
       filterOptions,
+      filterRepo,
+      showRepoFilter,
+      toggleRepoFilter,
       onSearch,
     };
   },
@@ -1023,7 +1050,6 @@ table {
   padding-top: 40px; 
 }
 
-
 th, td {
   border: 1px solid #ddd;
   white-space: pre-line;
@@ -1044,6 +1070,32 @@ th {
 
 tr:hover {
   background: var(--color-background-mute);
+}
+
+.repo-filter-dropdown {
+  position: absolute; /* 或者其他合适的定位方式 */
+  background: white; /* 下拉菜单背景 */
+  top: 100%; /* 使下拉菜单在表头下方 */
+  left: 0;
+  border-radius: 4px;
+  border: 1px solid #ccc; /* 边框 */
+  z-index: 1000; /* 确保在其他元素之上 */
+}
+.repo-filter-dropdown ul {
+  list-style: none; /* 去掉默认的列表样式 */
+  padding: 0; /* 去掉内边距 */
+  margin: 0; /* 去掉外边距 */
+}
+.repo-filter-dropdown li {
+  padding: 8px 12px; /* 添加内边距 */
+  cursor: pointer; /* 鼠标悬停时显示为手指 */
+}
+.repo-filter-dropdown li:hover {
+  background: #f0f0f0; /* 悬停时的背景颜色 */
+}
+
+.clickable {
+  cursor: pointer; /* 鼠标悬停时显示为可点击 */
 }
 
 input {

--- a/loong-status/front/src/components/DataTable.vue
+++ b/loong-status/front/src/components/DataTable.vue
@@ -332,7 +332,7 @@ export default {
 
     const selectFilter = (label) => {
       label = label === 'All failed builds' ? 'Success' : label
-      selectedErrorType = selectedErrorType === label ? null : label
+      selectedErrorType.value = selectedErrorType.value === label ? null : label
       showFilter.value = false
       fetchData()
     }

--- a/loong-status/front/src/components/DataTable.vue
+++ b/loong-status/front/src/components/DataTable.vue
@@ -852,15 +852,16 @@ export default {
 .sidebar-content {
   padding: 1rem;
   height: calc(100% - 60px);
-  overflow-y: auto;
+  overflow-y: hidden;
 }
 
 .sidebar-table {
   width: 100%;
+  height: 100%;
   table-layout: auto;
   min-width: 380px;
   border-collapse: collapse;
-  overflow-x: auto;
+  overflow: visible;
   display: block; 
   scroll-behavior: smooth;
   th, td {
@@ -880,7 +881,8 @@ export default {
 }
 
 .sidebar-table thead {
-  display: block;
+  display: table;
+  width: 100%;
   position: sticky;
   top: 0;
   z-index: 10;

--- a/loong-status/front/src/components/DataTable.vue
+++ b/loong-status/front/src/components/DataTable.vue
@@ -233,7 +233,7 @@ export default {
 
       status += '&nbsp';
       if (item.has_log === true) {
-        const encodedVersion = encodeURIComponent(item.x86_version);
+        const encodedVersion = encodeURIComponent(item.loong_version);
         const logUrl = `/log?base=${item.base}&name=${item.name}&version=${encodedVersion}`;
         status += `<span><a href="${logUrl}" target="_blank" style="color: gold;">🅻</a></span>`;      
       } else {

--- a/loong-status/front/src/components/DataTable.vue
+++ b/loong-status/front/src/components/DataTable.vue
@@ -184,7 +184,7 @@
 
 <script>
 import { useRoute } from 'vue-router';
-import { ref, reactive, computed, onMounted } from 'vue';
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue';
 import axios from 'axios';
 
 export default {
@@ -324,11 +324,41 @@ export default {
 
     const totalPages = computed(() => Math.ceil(total.value / perPage.value)) || 1;
 
+    // Close dropdown when clicking outside
+    const handleClickOutside = (event) => {
+      const filterPanel = document.querySelector('.filter-panel');
+      const filterBtn = document.querySelector('.filter-btn');
+      const repoDropdown = document.querySelector('.repo-filter-dropdown');
+      const repoBtn = document.querySelector('.clickable'); 
+
+      const clickedOutside = (box, btn) => {
+      const target = event.target;
+      // Not in the filter panel or button
+      return box && !box.contains(target) && (!btn || !btn.contains(target));
+      };
+
+      if (showFilter.value && clickedOutside(filterPanel, filterBtn)) {
+      showFilter.value = false; 
+      console.log('Close filter');
+      }
+
+      if (showRepoFilter.value && clickedOutside(repoDropdown, repoBtn)) {
+      showRepoFilter.value = false; 
+      console.log('Close repo filter');
+      }
+      };
+
+
     onMounted(() => {
+      document.addEventListener('click', handleClickOutside);
       searchName.value = route.query.name?.trim() || null;
       selectedErrorType.value = route.query.error_type?.trim() || null;
       selectedRepo.value = route.query.repo?.trim() || null;
       fetchData();
+    });
+
+    onBeforeUnmount(() => {
+      document.removeEventListener('click', handleClickOutside);
     });
 
     // const onStatusChange = () => {
@@ -1073,29 +1103,29 @@ tr:hover {
 }
 
 .repo-filter-dropdown {
-  position: absolute; /* 或者其他合适的定位方式 */
-  background: white; /* 下拉菜单背景 */
-  top: 100%; /* 使下拉菜单在表头下方 */
+  position: absolute; 
+  background: white;
+  top: 100%; 
   left: 0;
   border-radius: 4px;
-  border: 1px solid #ccc; /* 边框 */
-  z-index: 1000; /* 确保在其他元素之上 */
+  border: 1px solid #ccc; 
+  z-index: 1000; 
 }
 .repo-filter-dropdown ul {
-  list-style: none; /* 去掉默认的列表样式 */
-  padding: 0; /* 去掉内边距 */
-  margin: 0; /* 去掉外边距 */
+  list-style: none; 
+  padding: 0; 
+  margin: 0; 
 }
 .repo-filter-dropdown li {
-  padding: 8px 12px; /* 添加内边距 */
-  cursor: pointer; /* 鼠标悬停时显示为手指 */
+  padding: 8px 12px; 
+  cursor: pointer; 
 }
 .repo-filter-dropdown li:hover {
-  background: #f0f0f0; /* 悬停时的背景颜色 */
+  background: #6b2024; 
 }
 
 .clickable {
-  cursor: pointer; /* 鼠标悬停时显示为可点击 */
+  cursor: pointer;
 }
 
 input {

--- a/loong-status/isloongupdated/Cargo.lock
+++ b/loong-status/isloongupdated/Cargo.lock
@@ -1198,6 +1198,7 @@ dependencies = [
  "actix-web",
  "chrono",
  "dotenv",
+ "log",
  "r2d2",
  "reqwest",
  "serde",

--- a/loong-status/isloongupdated/Cargo.toml
+++ b/loong-status/isloongupdated/Cargo.toml
@@ -13,6 +13,7 @@ serde = { version = "1.0.210", features = ["derive"]}
 sqlx = { version = "0.8.2", features = ["postgres", "runtime-tokio", "chrono"]}
 tempfile = "3.12.0"
 tokio = { version = "1.40.0", features = ["full"] }
+log = "0.4.27"
 
 [[bin]]
 name = "loong-updator"

--- a/loong-status/isloongupdated/src/api/main.rs
+++ b/loong-status/isloongupdated/src/api/main.rs
@@ -5,6 +5,7 @@ use sqlx::{postgres::PgPoolOptions, FromRow, Row};
 use chrono::NaiveDateTime;
 use std::fs::read_to_string;
 use std::path::Path;
+use log;
 
 #[derive(Serialize, Debug, FromRow)]
 struct Package {

--- a/loong-status/isloongupdated/src/api/main.rs
+++ b/loong-status/isloongupdated/src/api/main.rs
@@ -150,12 +150,12 @@ async fn get_stat(pool: web::Data<sqlx::Pool<sqlx::Postgres>>) -> impl Responder
     let counts = sqlx::query_as::<_, CountResponse>(
         r#"
         SELECT
-            COUNT(*) FILTER (WHERE repo = 'core' AND x86_version = loong_version) AS core_match,
-            COUNT(*) FILTER (WHERE repo = 'extra' AND x86_version = loong_version) AS extra_match,
-            COUNT(*) FILTER (WHERE repo = 'core' AND x86_version != loong_version AND x86_version != 'missing' AND loong_version != 'missing') AS core_mismatch,
-            COUNT(*) FILTER (WHERE repo = 'extra' AND x86_version != loong_version AND x86_version != 'missing' AND loong_version != 'missing') AS extra_mismatch,
-            COUNT(*) FILTER (WHERE repo='core' AND NOT x86_version is NULL) as core_total,
-            COUNT(*) FILTER (WHERE repo='extra' AND NOT x86_version is NULL) as extra_total
+            COUNT(*) FILTER (WHERE repo = 'core' AND split_part(x86_version, '-', 1) = split_part(loong_version, '-', 1)) AS core_match,
+            COUNT(*) FILTER (WHERE repo = 'extra' AND split_part(x86_version, '-', 1) = split_part(loong_version, '-', 1)) AS extra_match,
+            COUNT(*) FILTER (WHERE repo = 'core' AND split_part(x86_version, '-', 1) != split_part(loong_version, '-', 1) AND x86_version != 'missing' AND loong_version != 'missing') AS core_mismatch,
+            COUNT(*) FILTER (WHERE repo = 'extra' AND split_part(x86_version, '-', 1) != split_part(loong_version, '-', 1) AND x86_version != 'missing' AND loong_version != 'missing') AS extra_mismatch,
+            COUNT(*) FILTER (WHERE repo = 'core' AND x86_version != 'missing') as core_total,
+            COUNT(*) FILTER (WHERE repo = 'extra' AND x86_version != 'missing') as extra_total
         FROM packages
         "#
     )

--- a/loong-status/isloongupdated/src/api/main.rs
+++ b/loong-status/isloongupdated/src/api/main.rs
@@ -42,7 +42,8 @@ struct QueryParams {
     page: Option<u32>,
     per_page: Option<u32>,
     name: Option<String>,
-    error_type: Option<String>
+    error_type: Option<String>,
+    repo: Option<String>,
 }
 
 #[derive(Serialize, Debug, FromRow)]
@@ -195,6 +196,7 @@ async fn get_data(
             query_builder.push(" AND ");
         } else {
             query_builder.push(" WHERE ");
+            where_added = true;
         }
             query_builder.push("error_type ");
             match query.error_type.as_deref() {
@@ -203,6 +205,16 @@ async fn get_data(
             };
             query_builder.push_bind(error_type);
         
+    }
+
+    if let Some(repo) = &query.repo {
+        if where_added {
+            query_builder.push(" AND ");
+        } else {
+            query_builder.push(" WHERE ");
+        }
+        query_builder.push("repo = ");
+        query_builder.push_bind(repo);
     }
     
     query_builder
@@ -234,6 +246,7 @@ async fn get_data(
             count_builder.push(" AND ");
         } else {
             count_builder.push(" WHERE ");
+            where_added = true;
         }
         count_builder.push("error_type ");
         match query.error_type.as_deref() {
@@ -241,6 +254,16 @@ async fn get_data(
                 _ => count_builder.push("= ")
             };
         count_builder.push_bind(error_type);
+    }
+
+    if let Some(repo) = &query.repo {
+        if where_added {
+            count_builder.push(" AND ");
+        } else {
+            count_builder.push(" WHERE ");
+        }
+        count_builder.push("repo = ");
+        count_builder.push_bind(repo);
     }
 
     let total = match count_builder.build().fetch_one(pool.get_ref()).await {

--- a/scripts/1build.sh
+++ b/scripts/1build.sh
@@ -122,23 +122,13 @@ build_package() {
             cd $PKGBASE
         fi
 
-        # PKGNAME=$(. PKGBUILD; echo $pkgname)
-        # if [[ -z "$PKGVER" ]]; then
-        #     # get the release tag from x86_64's repo
-        #     if [[ ! -z "$TESTING" ]]; then
-        #         REPOSWITCH=-${TESTING%ing}
-        #     fi
-        #     PKGVER=`$SCRIPTSPATH/compare86.py $REPOSWITCH -p $PKGNAME |grep x86_64|awk -F= '{print $2}'`
-        # fi
-
         # switch to the current release tag
         PKGVER=$(echo "$PKGVERREL" | sed 's/^\(.*-[0-9]\+\)\..*$/\1/')
 
         if [[ ! -z "$PKGVERREL" ]]; then
             if ! pkgctl repo switch $PKGVER; then
                 msg "Release tag could not be found."
-                EXITCODE=1
-                return
+                return 1
             fi
         fi
         # if [[ ! -z "$PKGVER" ]]; then
@@ -151,8 +141,7 @@ build_package() {
         if [[ -d "$LOONGREPO/$PKGBASE" ]]; then
             if ! patch -Np1 -i $LOONGREPO/$PKGBASE/loong.patch; then
                 msg "Fail to apply loong's patch."
-                EXITCODE=1
-                return
+                return 1
             fi
             # copy additional files
             find $LOONGREPO/$PKGBASE -type f -name "*" ! -name "loong.patch" -exec cp {} . \;
@@ -160,50 +149,12 @@ build_package() {
         fi
     fi
 
-    # TODO: How to handle this? package may not in arch's repo
-    # if [[ -z "$PKGVER" ]]; then
-    #     PKGVERREL=$(source PKGBUILD; echo $epoch${epoch:+:}$pkgver-$pkgrel)
-    # else
-    #     PKGVERREL=$PKGVER
-    # fi
-
-    # if [[ -z "$BUILDREPO" ]]; then
-    #     BUILDREPO=$($SCRIPTSPATH/compare86.py $REPOSWITCH -p $PKGNAME | awk '{print $5}' | tail -1)
-    #     BUILDREPO=${BUILDREPO%-staging}
-    #     BUILDREPO=${BUILDREPO%-testing}
-    # fi
     echo "Checking package repo"
     if [[ -z "$BUILDREPO" ]]; then
         # BUILDREPO="extra"  # default to extra
         echo "Build repo not specified!"
-        EXITCODE=1
-	    return 
+	    return 1
     fi
-
-    # if grep -qFx "$PKGBASE" $SCRIPTSPATH/trueany.lst; then
-    #     MIRRORSITE=https://mirrors.pku.edu.cn/archlinux
-    #     cd $LOCALREPO/temp-$BUILDREPO$TESTING/os/loong64
-    #     (source $WORKDIR/$PKGBASE/PKGBUILD;
-    #     for pkg in ${pkgname[@]}; do
-    #         FILENAME=$pkg-$PKGVERREL-any.pkg.tar.zst
-    #         wget $MIRRORSITE/$BUILDREPO$TESTING/os/x86_64/$FILENAME
-    #         wget $MIRRORSITE/$BUILDREPO$TESTING/os/x86_64/$FILENAME.sig
-    #         chmod 644 $FILENAME
-    #         chmod 644 $FILENAME.sig
-    #         repo-add -R temp-$BUILDREPO$TESTING.db.tar.gz $FILENAME
-    #     done)
-    #     return 2
-    # fi
-
-    # Try to find the pkgver from tier0 server
-    # _PKGVER=$($SCRIPTSPATH/compare86.py -sTp $PKGNAME | grep "$BUILDREPO$TESTING of loong64 with ver=$PKGVERREL" | awk -F= '{print $2}')
-    # if [[ ! -z "$_PKGVER" ]]; then
-    #     # Same package found in server. Incrementing point pkgrel...
-    #     PKGREL=${_PKGVER#*-}
-    #     PKGREL=$(echo $PKGREL + .1 | bc)
-    #     sed -i "s/^pkgrel=.*/pkgrel=$PKGREL/" PKGBUILD
-    #     PKGVERREL=${PKGVERREL%-*}-$PKGREL
-    # fi
 
     echo "Running pre-built fix"
 
@@ -240,8 +191,7 @@ build_package() {
     rsync -avzP --mkpath $WORKDIR/$PKGBASE/ $BUILDER:$BUILDPATH/$PKGBASE/ $NOKEEP --exclude=.*
     if [[ ! $? -eq 0 ]]; then
         msg "Can't copy PKGBUILD to builder."
-        EXITCODE=2
-        return
+        return 1
     fi
     
     # Start to build package
@@ -262,13 +212,17 @@ build_package() {
         fi
         # cd $LOCALREPO/temp-$BUILDREPO$TESTING/os/loong64
         mkdir -p $LOCALREPO/debug-pool
+        # Remove old files
+        if [[ -f $LOCALREPO/$PKGBASE ]]; then
+            rm -rf $LOCALREPO/$PKGBASE
+        fi
         mkdir -p $LOCALREPO/$PKGBASE
 	    cd $LOCALREPO/$PKGBASE
         # for pkg in ${pkgname[@]}; do
         # FILENAME=$pkg-$PKGVERREL-$ARCH.pkg.tar.zst
 
         # All packages
-    	FILENAME=*.pkg.tar.zst
+    	FILENAME="*.pkg.tar.zst"
         # Only debug packages
         DEBUGPKG=$PKGBASE-debug-$PKGVERREL-loong64.pkg.tar.zst
 	    if [ "$BUILDER" = "loong1" ]; then
@@ -276,17 +230,17 @@ build_package() {
             ssh -t $BUILDER "cd $BUILDPATH/$PKGBASE && \
                 for file in *.pkg.tar.zst; do \
                     rm -f \"\$file.sig\"; \
-                    gpg --detach-sign \"\$file\"; \
+                    gpg --detach-sign \"\$file\" && echo \"\$file.sig created\" || echo \"\$file signing failed\"; \
                 done"            
             scp loong1:/tmp/"$FILENAME" loong1:/tmp/"${FILENAME}.sig" .
         else # Only loong1 has the signing key
             echo "Sending package to loong1 for signing"
-            scp "$BUILDER:$BUILDPATH/$PKGBASE/$FILENAME" .
-            scp $FILENAME "loong1:/tmp/"
+            scp "$BUILDER:$BUILDPATH/$PKGBASE/$FILENAME" . || echo "File copy failed";
+            scp $FILENAME "loong1:/tmp/" || echo "File copy failed to loong1";
             ssh -t loong1 "cd /tmp && \
             for file in *.pkg.tar.zst; do \
                 rm -f \"\$file.sig\"; \
-                gpg --detach-sign \"\$file\"; \
+                gpg --detach-sign \"\$file\" && echo \"\$file.sig created\" || echo \"\$file signing failed\"; \
             done"
             scp loong1:/tmp/"${FILENAME}.sig" .
             ssh -t loong1 "rm /tmp/$FILENAME{,.sig} -f"
@@ -294,22 +248,8 @@ build_package() {
         chmod 664 $FILENAME{,.sig}
 	    mv $DEBUGPKG{,.sig} $LOCALREPO/debug-pool
         repo-add -R $LOCALREPO/temp-$BUILDREPO$TESTING.db.tar.gz $FILENAME
-        # done)
     	)
-        # DEBUGPKG=$PKGBASE-debug-$PKGVERREL-loong64.pkg.tar.zst
-        # echo $DEBUGPKG
-        # if ssh -t $BUILDER "cd $BUILDPATH/$PKGBASE; if [ -f $DEBUGPKG ]; then rm -f $DEBUGPKG.sig; gpg --detach-sign $DEBUGPKG; fi; [ -f $BUILDPATH/$PKGBASE/$DEBUGPKG ]" 2>/dev/null; then
-        #     if [ "$BUILDER" = "loong1" ]; then
-        #         scp $BUILDER:$BUILDPATH/$PKGBASE/$DEBUGPKG{,.sig} $LOCALREPO/debug-pool
-        #     else # Only loong1 has the signing key
-        #         scp $BUILDER:$BUILDPATH/$PKGBASE/$DEBUGPKG $LOCALREPO/debug-pool
-        #         scp "$LOCALREPO/debug-pool/$DEBUGPKG" "loong1:/mnt/repos/"
-        #         ssh -t loong1 "cd /mnt/repos; gpg --detach-sign $DEBUGPKG"
-        #         scp loong1:/mnt/repos/$DEBUGPKG.sig $LOCALREPO/debug-pool
-        #         ssh -t loong1 "cd /mnt/repos; rm $DEBUGPKG{,.sig} -f"
-        #     fi
-        #     chmod 664 $LOCALREPO/debug-pool/$DEBUGPKG{,.sig}
-        # fi
+
         msg "$PKGBASE-$PKGVERREL built on $BUILDER, time cost: $TIMECOST"
 	else
         msg "$PKGBASE-$PKGVERREL failed on $BUILDER, time cost: $TIMECOST, exit code: $EXITCODE"

--- a/scripts/1build.sh
+++ b/scripts/1build.sh
@@ -104,7 +104,7 @@ done
 EXTRAARG="$@"
 
 build_package() {
-    # packages beloong only to loong
+    # packages belong only to loong
     if [[ -f $LOONGREPO/$PKGBASE/PKGBUILD ]]; then
         cp $LOONGREPO/$PKGBASE $WORKDIR/ -a
         cd $WORKDIR/$PKGBASE
@@ -196,7 +196,8 @@ build_package() {
     
     # Start to build package
     echo "Sending build command"
-    ssh -t $BUILDER "cd $BUILDPATH/$PKGBASE; PACKAGER=\"$PACKAGER\" extra$TESTING-loong64-build $CLEAN -- -- -A -L $EXTRAARG" 2>/dev/null
+    ssh $BUILDER "cd $BUILDPATH/$PKGBASE; PACKAGER=\"$PACKAGER\" extra$TESTING-loong64-build $CLEAN -- -- -A -L $EXTRAARG"
+    # 2>/dev/null
     EXITCODE=$?
 
     ENDTIME=$SECONDS
@@ -210,16 +211,9 @@ build_package() {
         else
             ARCH="loong64"
         fi
-        # cd $LOCALREPO/temp-$BUILDREPO$TESTING/os/loong64
+
         mkdir -p $LOCALREPO/debug-pool
-        # Remove old files
-        if [[ -f $LOCALREPO/$PKGBASE ]]; then
-            rm -rf $LOCALREPO/$PKGBASE
-        fi
-        mkdir -p $LOCALREPO/$PKGBASE
-	    cd $LOCALREPO/$PKGBASE
-        # for pkg in ${pkgname[@]}; do
-        # FILENAME=$pkg-$PKGVERREL-$ARCH.pkg.tar.zst
+        cd $LOCALREPO
 
         # All packages
     	FILENAME="*.pkg.tar.zst"
@@ -263,6 +257,9 @@ mkdir -p $LOGPATH/$PKGBASE
 build_package | tee $PKGBASE-$PKGVERREL.log
 EXITCODE=${PIPESTATUS[0]}
 
+if [[ -f $LOGPATH/$PKGBASE/$PKGBASE-$PKGVERREL.log ]]; then
+    rm $LOGPATH/$PKGBASE/$PKGBASE-$PKGVERREL.log
+fi
 cp $PKGBASE-$PKGVERREL.log $LOGPATH/$PKGBASE/$PKGBASE-$PKGVERREL.log
 
 if [[ "$EXITCODE" -ne 0 ]]; then

--- a/scripts/1build.sh
+++ b/scripts/1build.sh
@@ -1,0 +1,322 @@
+#!/bin/bash
+
+# ===== Variables you should check ======
+TEMP=$HOME
+LOONGREPO=${LOONGREPO:=$TEMP/loongarch-packages}
+WORKDIR=${WORKDIR:=$TEMP/repos}
+ZSTLOGDIR=${ZSTLOGDIR:=$TEMP/logs}
+PACKAGER=${PACKAGER:="LCPU <lcpu@pku.edu.cn>"}
+SCRIPTSPATH=${SCRIPTSPATH:=$TEMP/loongshot/scripts}
+LOGPATH=/home/arch/loong-status/build_logs # This is for webserver
+# LOCALREPO=/srv/http/build-repo
+LOCALREPO=/var/tmp/build-repo
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: ${0##*/} <pkgbase> [option]"
+    echo "Option:"
+    echo "  --stag     Use staging repo."
+    echo "  --test     Use testing repo."
+    echo "  --ver      Build a specific version."
+    echo "  --repo     core or extra."
+    echo "  --clean    Clean the chroot directory."
+    echo "  --builder  Build machine to use, default is 'localhost'."
+    echo "             Remote builder syntax is <host>:<workdir>"
+    echo "  --delsrc   Delete downloaded and generated files."
+    echo "  --debug    Just build the package, don't inform server."
+    echo "  --         Options after this will be passed to makepkg."
+    exit 1
+fi
+
+export LC_ALL=en_US.UTF-8
+
+PKGBASE=$1
+shift
+
+TESTING="" # use extra-loong64-build by default
+PKGVER=""
+CLEAN=""
+BUILDER="localhost"
+# workdir for the builder
+BUILDPATH=/var/tmp/build-loong64-pkgs
+DEBUG=""
+
+source /usr/share/makepkg/util/message.sh
+colorize
+
+if [ ! -d "$LOONGREPO" ] || [ ! -d "$WORKDIR" ]; then
+    error "Please set LOONGREPO and WORKDIR in the source code..."
+    exit 1
+    # mkdir -p "$LOONGREPO"
+    # mkdir -p "$WORKDIR"
+fi
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --stag)
+            TESTING="-staging"
+            shift
+            ;;
+        --test)
+            TESTING="-testing"
+            shift
+            ;;
+        --ver)
+            shift
+            PKGVER=$1
+            shift
+            ;;
+        --repo)
+            shift
+            BUILDREPO=$1
+            shift
+            ;;
+        --clean)
+            CLEAN="-c"
+            shift
+            ;;
+        --debug)
+            DEBUG="yes"
+            shift
+            ;;
+        --builder)
+            shift
+            BUILDER=${1%:*}
+            BP=${1#*:}
+            if [[ "$BP" != "$BUILDER" ]]; then
+                BUILDPATH="$BP"
+            fi
+            shift
+            ;;
+        --delsrc)
+            NOKEEP="--delete --delete-excluded"
+            shift
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+EXTRAARG="$@"
+
+build_package() {
+    # packages beloong only to loong
+    if [[ -f $LOONGREPO/$PKGBASE/PKGBUILD ]]; then
+        cp $LOONGREPO/$PKGBASE $WORKDIR/ -a
+        cd $WORKDIR/$PKGBASE
+        PKGNAME=$(. PKGBUILD; echo $pkgname)
+    else
+        # clone arch package repo
+        if [[ -d $WORKDIR/$PKGBASE ]]; then
+            cd $WORKDIR/$PKGBASE
+            pkgctl repo switch main -f
+            git pull 2>&1 || return
+        else
+            cd $WORKDIR 2>&1 || return
+	    get-loong64-pkg $PKGBASE
+            # pkgctl repo clone --protocol=https $PKGBASE 2>&1 || return
+            cd $PKGBASE
+        fi
+
+        # PKGNAME=$(. PKGBUILD; echo $pkgname)
+        # if [[ -z "$PKGVER" ]]; then
+        #     # get the release tag from x86_64's repo
+        #     if [[ ! -z "$TESTING" ]]; then
+        #         REPOSWITCH=-${TESTING%ing}
+        #     fi
+        #     PKGVER=`$SCRIPTSPATH/compare86.py $REPOSWITCH -p $PKGNAME |grep x86_64|awk -F= '{print $2}'`
+        # fi
+
+        # switch to the current release tag
+        if [[ ! -z "$PKGVER" ]]; then
+            if ! pkgctl repo switch ${PKGVER//:/-}; then
+                msg "Release tag could not be found."
+                return
+            fi
+        fi
+        # apply patch
+        if [[ -d "$LOONGREPO/$PKGBASE" ]]; then
+            if ! patch -Np1 -i $LOONGREPO/$PKGBASE/loong.patch; then
+                msg "Fail to apply loong's patch."
+                return
+            fi
+            # copy additional files
+            find $LOONGREPO/$PKGBASE -type f -name "*" ! -name "loong.patch" -exec cp {} . \;
+            msg "Loong's patch applied."
+        fi
+    fi
+
+    # TODO: How to handle this? package may not in arch's repo
+    # if [[ -z "$PKGVER" ]]; then
+    #     PKGVERREL=$(source PKGBUILD; echo $epoch${epoch:+:}$pkgver-$pkgrel)
+    # else
+    #     PKGVERREL=$PKGVER
+    # fi
+
+    # if [[ -z "$BUILDREPO" ]]; then
+    #     BUILDREPO=$($SCRIPTSPATH/compare86.py $REPOSWITCH -p $PKGNAME | awk '{print $5}' | tail -1)
+    #     BUILDREPO=${BUILDREPO%-staging}
+    #     BUILDREPO=${BUILDREPO%-testing}
+    # fi
+    echo "Checking package repo"
+    if [[ -z "$BUILDREPO" ]]; then
+        # BUILDREPO="extra"  # default to extra
+        echo "Build repo not specified!"
+	return 1
+    fi
+
+    # if grep -qFx "$PKGBASE" $SCRIPTSPATH/trueany.lst; then
+    #     MIRRORSITE=https://mirrors.pku.edu.cn/archlinux
+    #     cd $LOCALREPO/temp-$BUILDREPO$TESTING/os/loong64
+    #     (source $WORKDIR/$PKGBASE/PKGBUILD;
+    #     for pkg in ${pkgname[@]}; do
+    #         FILENAME=$pkg-$PKGVERREL-any.pkg.tar.zst
+    #         wget $MIRRORSITE/$BUILDREPO$TESTING/os/x86_64/$FILENAME
+    #         wget $MIRRORSITE/$BUILDREPO$TESTING/os/x86_64/$FILENAME.sig
+    #         chmod 644 $FILENAME
+    #         chmod 644 $FILENAME.sig
+    #         repo-add -R temp-$BUILDREPO$TESTING.db.tar.gz $FILENAME
+    #     done)
+    #     return 2
+    # fi
+
+    # Try to find the pkgver from tier0 server
+    # _PKGVER=$($SCRIPTSPATH/compare86.py -sTp $PKGNAME | grep "$BUILDREPO$TESTING of loong64 with ver=$PKGVERREL" | awk -F= '{print $2}')
+    # if [[ ! -z "$_PKGVER" ]]; then
+    #     # Same package found in server. Incrementing point pkgrel...
+    #     PKGREL=${_PKGVER#*-}
+    #     PKGREL=$(echo $PKGREL + .1 | bc)
+    #     sed -i "s/^pkgrel=.*/pkgrel=$PKGREL/" PKGBUILD
+    #     PKGVERREL=${PKGVERREL%-*}-$PKGREL
+    # fi
+
+    echo "Running pre-built fix"
+
+    # for rust packages, $CARCH need to change to `uname -m`=loongarch64
+    sed -i '/cargo fetch/s/\$CARCH\|\${CARCH}\|x86_64/`uname -m`/' PKGBUILD
+
+    # When use cpython, $CARCH also need to chage to `uname -m`
+    sed -i 's/lib\.linux-\$CARCH-\|lib\.linux-\${CARCH}-/lib.linux-`uname -m`-/g; s/lib\.linux-x86_64-cpython/lib.linux-`uname -m`-cpython/' PKGBUILD
+
+    # More lua packages are building with luarocks, so..
+    sed -i 's/linux-\$CARCH.rock/linux-`uname -m`.rock/g' PKGBUILD
+
+    # insert two lines of code after cd to the source.
+    update_config() {
+        cd $WORKDIR/$PKGBASE
+        sed -i '/^build()/,/configure/ {/^[[:space:]]*cd[[:space:]]\+/ { s/$/\n  for c_s in $(find -type f -name config.sub -o -name configure.sub); do cp -f \/usr\/share\/automake-1.1?\/config.sub "$c_s"; done\n  for c_g in $(find -type f -name config.guess -o -name configure.guess); do cp -f \/usr\/share\/automake-1.1?\/config.guess "$c_g"; done/; t;};}' PKGBUILD
+    }
+
+    if grep -q "^$PKGBASE$" "$LOONGREPO/update_config"; then
+        update_config
+        msg "Updating config.{sub,guess}."
+    fi
+
+    if grep -q "^$PKGBASE$" "$LOONGREPO/ruby_mapping"; then
+        echo "checkdepends+=(ruby-mapping)" >> PKGBUILD
+    fi
+
+    for arg in ${EXTRAARG[@]}; do
+        msg "Build with $arg."
+    done
+
+    # Transferring PKGBUILD to builder machine
+    STARTTIME=$SECONDS
+    rsync -avzP --mkpath $WORKDIR/$PKGBASE/ $BUILDER:$BUILDPATH/$PKGBASE/ $NOKEEP --exclude=.*
+    if [[ ! $? -eq 0 ]]; then
+        msg "Can't copy PKGBUILD to builder."
+        return 2
+    fi
+    
+    # Start to build package
+    echo "Sending build command"
+    ssh -t $BUILDER "cd $BUILDPATH/$PKGBASE; PACKAGER=\"$PACKAGER\" extra$TESTING-loong64-build $CLEAN -- -- -A -L $EXTRAARG" 2>/dev/null
+    EXITCODE=$?
+
+    ENDTIME=$SECONDS
+    TIMECOST=$((ENDTIME - STARTTIME))
+
+    # add the zst file to the local-repo
+    if [[ "$EXITCODE" -eq 0 ]] && [[ ! "$DEBUG" == "yes" ]]; then
+        (source PKGBUILD;
+        if [[ "$arch" == "any" ]]; then
+            ARCH="any"
+        else
+            ARCH="loong64"
+        fi
+        # cd $LOCALREPO/temp-$BUILDREPO$TESTING/os/loong64
+	    cd $WORKDIR/$PKGBASE
+        # for pkg in ${pkgname[@]}; do
+        # FILENAME=$pkg-$PKGVERREL-$ARCH.pkg.tar.zst
+
+        # All packages
+    	FILENAME=*.pkg.tar.zst
+        # Only debug packages
+        DEBUGPKG=$PKGBASE-debug-$PKGVER-loong64.pkg.tar.zst
+	    if [ "$BUILDER" = "loong1" ]; then
+            echo "Signing package on loong1"
+            ssh -t $BUILDER "cd $BUILDPATH/$PKGBASE; [[ -f $FILENAME.sig ]] && rm -f $FILENAME.sig; gpg --detach-sign $FILENAME" 
+            scp $BUILDER:$BUILDPATH/$PKGBASE/$FILENAME{,.sig} .
+        else # Only loong1 has the signing key
+            echo "Sending package to loong1 for signing"
+            scp $BUILDER:$BUILDPATH/$PKGBASE/$FILENAME .
+            scp "./$FILENAME" "loong1:/temp/"
+            ssh -t loong1 "cd /tmp; gpg --detach-sign $FILENAME"
+            scp loong1:/tmp/$FILENAME.sig .
+            ssh -t loong1 "rm /tmp/$FILENAME{,.sig} -f"
+        fi
+        chmod 664 $FILENAME{,.sig}
+	    mv $DEBUGPKG{,.sig} $LOCALREPO/debug-pool
+        repo-add -R $WORKDIR/temp-$BUILDREPO$TESTING.db.tar.gz $FILENAME
+        # done)
+    	)
+        # DEBUGPKG=$PKGBASE-debug-$PKGVERREL-loong64.pkg.tar.zst
+        # echo $DEBUGPKG
+        # if ssh -t $BUILDER "cd $BUILDPATH/$PKGBASE; if [ -f $DEBUGPKG ]; then rm -f $DEBUGPKG.sig; gpg --detach-sign $DEBUGPKG; fi; [ -f $BUILDPATH/$PKGBASE/$DEBUGPKG ]" 2>/dev/null; then
+        #     if [ "$BUILDER" = "loong1" ]; then
+        #         scp $BUILDER:$BUILDPATH/$PKGBASE/$DEBUGPKG{,.sig} $LOCALREPO/debug-pool
+        #     else # Only loong1 has the signing key
+        #         scp $BUILDER:$BUILDPATH/$PKGBASE/$DEBUGPKG $LOCALREPO/debug-pool
+        #         scp "$LOCALREPO/debug-pool/$DEBUGPKG" "loong1:/mnt/repos/"
+        #         ssh -t loong1 "cd /mnt/repos; gpg --detach-sign $DEBUGPKG"
+        #         scp loong1:/mnt/repos/$DEBUGPKG.sig $LOCALREPO/debug-pool
+        #         ssh -t loong1 "cd /mnt/repos; rm $DEBUGPKG{,.sig} -f"
+        #     fi
+        #     chmod 664 $LOCALREPO/debug-pool/$DEBUGPKG{,.sig}
+        # fi
+        msg "$PKGBASE-$PKGVER built on $BUILDER, time cost: $TIMECOST"
+	else
+        msg "$PKGBASE-$PKGVER failed on $BUILDER, time cost: $TIMECOST, exit code: $EXITCODE"
+    fi
+    return $EXITCODE
+}
+
+echo "Running 1build.sh"
+
+mkdir -p $LOGPATH/$PKGBASE
+build_package | tee $PKGBASE-$PKGVER.log
+EXITCODE=${PIPESTATUS[0]}
+
+cp $PKGBASE-$PKGVER.log $LOGPATH/$PKGBASE/$PKGBASE-$PKGVER.log
+
+if [[ "$EXITCODE" -ne 0 ]]; then
+   msg "Triggering faulty, exit code: $EXITCODE"
+   exit $EXITCODE
+fi
+# if [[ ${PIPESTATUS[0]} -eq 2 ]] || [[ "$DEBUG" == "yes" ]]; then
+#     exit 1
+# else
+#     # 1. mkdir for log. 2. upload. 3. parse the log
+#     mkdir -p $LOGPATH/$PKGBASE
+#     cp all.log.$BUILDER $LOGPATH/$PKGBASE/all.log
+#     parselog.py $PKGBASE
+#     if [[ -f $WORKDIR/$PKGBASE/PKGBUILD ]]; then
+#         PKGVERREL=$(source $WORKDIR/$PKGBASE/PKGBUILD; echo $epoch${epoch:+:}$pkgver-$pkgrel)
+#         mkdir -p $ZSTLOGDIR/$PKGBASE
+#         mv all.log.$BUILDER $ZSTLOGDIR/$PKGBASE/$PKGBASE-$PKGVERREL.log
+#     fi
+# fi

--- a/scripts/autobuild.py
+++ b/scripts/autobuild.py
@@ -63,7 +63,7 @@ def delete_record(db_path: str, record_id: int, new_loong_version, error = "Succ
             SELECT name, base, repo, %s, TRUE, x86_version, CASE WHEN %s = 'Success' THEN %s ELSE loong_version END
             FROM build_list
             WHERE task_no = %s
-            ON CONFLICT(name, repo) DO UPDATE SET
+            ON CONFLICT (name) DO UPDATE SET
             base = EXCLUDED.base,
             repo = EXCLUDED.repo,
             error_type = EXCLUDED.error_type,

--- a/scripts/autobuild.py
+++ b/scripts/autobuild.py
@@ -63,7 +63,7 @@ def delete_record(db_path: str, record_id: int, new_loong_version, error = "Succ
             SELECT name, base, repo, %s, TRUE, x86_version, CASE WHEN %s = 'Success' THEN %s ELSE loong_version END
             FROM build_list
             WHERE task_no = %s
-            ON CONFLICT(name) DO UPDATE SET
+            ON CONFLICT(name, repo) DO UPDATE SET
             base = EXCLUDED.base,
             repo = EXCLUDED.repo,
             error_type = EXCLUDED.error_type,
@@ -212,28 +212,7 @@ def main():
         builder = args.builder
     
     print(f"Database: {db}\nBuild List: {table}\nBuild script: {script}")
-    # Create the resulting packages table
-    # conn = dbinit.get_conn(db)
-    # cursor = conn.cursor()
-    # cursor.execute(f'''
-    #     CREATE TABLE IF NOT EXISTS packages (
-    #     name TEXT PRIMARY KEY,
-    #     base TEXT,
-    #     repo TEXT,
-    #     error_type TEXT,
-    #     has_log BOOL,
-    #     x86_version TEXT,
-    #     x86_testing_version TEXT,
-    #     x86_staging_version TEXT,
-    #     loong_version TEXT,
-    #     loong_testing_version TEXT,
-    #     loong_staging_version TEXT
-    #     )
-    # ''')
-    # conn.commit()
-    # cursor.close()
-    # conn.close()
-    
+        
     # Remove packages that are already in black list
     check_black_list(db)
     while True:

--- a/scripts/autobuild.py
+++ b/scripts/autobuild.py
@@ -47,6 +47,9 @@ def get_pending_task(db_path, table):
             conn.commit()
 
             return dict(record) if record else None
+    except psycopg2.Error as e:
+        conn.rollback()
+        raise RuntimeError(f"Database error: {e}") from e
     finally:
         conn.close()
 

--- a/scripts/autobuild.py
+++ b/scripts/autobuild.py
@@ -165,6 +165,10 @@ def execute_with_retry(script_path, db, record, builder):
             # If the build succeeds, new loong_version will be used, which might not be the same as the x86_version
             delete_record(db, record['task_no'], loong_version, error)
             return
+        
+    # If all retries failed, delete the record
+    print("Failed after retries... Now removing task")
+    delete_record(db, record['task_no'], loong_version, error)
 
 def check_black_list(db):
     conn = dbinit.get_conn(db)

--- a/scripts/autobuild.py
+++ b/scripts/autobuild.py
@@ -3,7 +3,10 @@ import compare86
 import dbinit
 import os
 import psycopg2
+import signal
 import subprocess
+import sys
+import termios
 import time
 from pathlib import Path
 from psycopg2 import extras
@@ -11,9 +14,9 @@ from psycopg2 import extras
 # Define retry triggers
 error_type = {
     "Fail to apply loong's patch": ["Fail to apply loong's patch"],
-    "Unknown error before build": ["Unknown error before build"],
+    "Unknown error before build": ["Unknown error before build", "Could not download sources"],
     "Fail to download source": ["Failure while downloading", "TLS connect error"],
-    "Fail to pass the validity check":["Fail to pass the validity check"],
+    "Fail to pass the validity check":["Fail to pass the validity check", "One or more files did not pass the validity check"],
     "Fail to pass PGP check" : ["One or more PGP signatures could not be verified"],
     "Could not resolve all dependencies": ["Could not resolve all dependencies"],
     "Failed in prepare": ["A failure occurred in prepare"],
@@ -22,6 +25,35 @@ error_type = {
     "Failed in package": ["A failure occurred in package"],
     "Cannot guess build type": ["configure: error: cannot guess build type"]
 }
+
+class BuildControl:
+    """
+    Handle Ctrl+C to show a simple menu for user to choose action
+    """
+    def __init__(self):
+        self.interrupted = False
+        self.action = None
+
+        # Register signal handler
+        signal.signal(signal.SIGINT, self._handle_interrupt)
+    
+    def _handle_interrupt(self, signum, frame):
+        """Ctrl+C = 显示菜单"""
+        self.interrupted = True
+        print("\n\n[s]kip | [q]uit | [Enter]=retry: ", end='', flush=True)
+        
+        # Set terminal to raw mode to capture single character input
+        try:
+            choice = input().strip().lower()
+            if choice == 's':
+                self.action = 'skip'
+            elif choice == 'q':
+                print("Exiting...")
+                self.action = 'quit'
+            else:
+                self.action = 'retry'
+        except EOFError:
+            sys.exit(0)
 
 # Fetch one task from build list
 def get_pending_task(db_path, table):
@@ -90,8 +122,9 @@ def delete_record(db_path: str, record_id: int, new_loong_version, error = "Succ
 
 # Execute build 
 def execute_with_retry(script_path, db, record, builder):
-    attempt = 0 #Retry attempts
-    max_retries=3
+    control = BuildControl()
+    attempt = 0 # Retry attempts
+    max_retries = 3
 
     x86_version = record['x86_version']
     loong_version = record['loong_version']
@@ -111,8 +144,15 @@ def execute_with_retry(script_path, db, record, builder):
         loong_version = x86_version
 
     print(f"Building {record['name']} with x86 version {x86_version} and loong version {loong_version}")
-
-    command = [
+    
+    systemd_cmd = [
+        "systemd-run",
+        "--user",
+        "--scope",
+        "--collect"
+    ]
+    unit = f"--unit=loongshot-{record['name']}-{time.time()}"
+    script_cmd = [
         script_path,
         record['name'],
         "--ver",
@@ -123,20 +163,53 @@ def execute_with_retry(script_path, db, record, builder):
         builder
     ]
 
+    command = systemd_cmd + [unit] + script_cmd
+
+    process = None
     while attempt < max_retries:
+        # Reset control state
+        control.interrupted = False
+        control.action = None
+        need_retry = False
+
         # Start running script
-        process = subprocess.run(
-            command,
-            text=True
-        )
+        process = subprocess.Popen(command, text=True)
         
-        # A success build
-        if process.returncode == 0:
+        while process.poll() is None:
+            # If interrupted, handle action
+            if control.interrupted and control.action:
+                # Stop the systemd service
+                subprocess.run(["systemctl", "--user", "stop", unit], 
+                                capture_output=True, timeout=60)
+                try:
+                    process.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait()
+                
+                if control.action == 'skip':
+                    delete_record(db, record['task_no'], loong_version, "skipped")
+                    return True
+                elif control.action == 'quit':
+                    delete_record(db, record['task_no'], loong_version, "QUIT by user")
+                    return False 
+                else:
+                    need_retry = True
+                    break
+            # Reset control state
+            control.interrupted = False  
+            control.action = None
+   
+        time.sleep(1)
+                
+        # Process finished, check return code
+        returncode = process.wait()
+        if returncode == 0:
+            print("✓ Build successful!")
             delete_record(db, record['task_no'], loong_version)
             return        
 
         # When build fails
-        need_retry = False
         error = ""
         with open(f"{record['name']}-{loong_version}.log", 'r') as f:
             lines = f.readlines()[-100:]
@@ -169,11 +242,12 @@ def execute_with_retry(script_path, db, record, builder):
             # If the build succeeds, new loong_version will be used, which might not be the same as the x86_version
             delete_record(db, record['task_no'], loong_version, error)
             return
-        
+
+
     # If all retries failed, delete the record
     print("Failed after retries... Now removing task")
     delete_record(db, record['task_no'], loong_version, error)
-
+    
 def check_black_list(db):
     conn = dbinit.get_conn(db)
     cursor = conn.cursor()
@@ -219,6 +293,7 @@ def main():
         
     # Remove packages that are already in black list
     check_black_list(db)
+
     while True:
 
         record = get_pending_task(db, table)
@@ -230,8 +305,10 @@ def main():
         print(f"\nTask ID={record['task_no']}, name={record['name']}, version={record['x86_version']}")
 
         try:
-            execute_with_retry(script, db, record, builder)  
-
+            success = execute_with_retry(script, db, record, builder)  
+            if success is False:
+                print("Exiting program as per user request.")
+                break
         except Exception as e:
             print(f"Failed to run script {e}")
             break

--- a/scripts/autobuild.py
+++ b/scripts/autobuild.py
@@ -67,6 +67,7 @@ def delete_record(db_path: str, record_id: int, new_loong_version, error = "Succ
             base = EXCLUDED.base,
             repo = EXCLUDED.repo,
             error_type = EXCLUDED.error_type,
+            has_log = EXCLUDED.has_log,
             x86_version = EXCLUDED.x86_version,
             loong_version = EXCLUDED.loong_version
         """, (error, error, new_loong_version, record_id,))

--- a/scripts/checksoname.py
+++ b/scripts/checksoname.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import dbinit
 import os
 import re
 import requests
@@ -58,21 +59,20 @@ def scan_directory_for_libs(dir_path, filename):
     return lib_versions
 
 def find_orphan_libs(links, files):
+    pkgs = []
     for lib_name, pkg_name in links.items():
         for pkg, version in pkg_name.items():
             allversion = set().union(*files[lib_name].values())
             if not version.issubset(allversion):
                 print(f"{pkg} links to orphan {lib_name}.so{list(version)[0]}")
+                pkgs.append(pkg)
+    return pkgs
 
 def main():
     parser = argparse.ArgumentParser(description="Check file db and links db for orphans.")
-    parser.add_argument("-C", "--core", action="store_true", help="Check core db.")
+    parser.add_argument("--db", help="Export")
 
     args = parser.parse_args()
-    if args.core:
-        repo = 'core'
-    else:
-        repo = 'extra'
 
     temp_dir = tempfile.TemporaryDirectory()
     links_dir = os.path.join(temp_dir.name, 'links')
@@ -83,20 +83,46 @@ def main():
                   f"{temp_dir.name}/core.files.tar.gz")
     print(f"core.files.tar.gz has downloaded.")
     extract_tar_gz(f"{temp_dir.name}/core.files.tar.gz", files_dir)
-    download_file(f"{mirror_loong64}extra/os/loong64/extra.files.tar.gz",
+    download_file(f"{mirror_loong64}extra/os/loong64/extra.files.tar.gz",   
                   f"{temp_dir.name}/extra.files.tar.gz")
     print(f"extra.files.tar.gz has downloaded.")
     extract_tar_gz(f"{temp_dir.name}/extra.files.tar.gz", files_dir)
 
-    download_file(f"{mirror_loong64}{repo}/os/loong64/{repo}.links.tar.gz",
-                  f"{temp_dir.name}/{repo}.links.tar.gz")
-    print(f"{repo}.links.tar.gz has downloaded.")
-    extract_tar_gz(f"{temp_dir.name}/{repo}.links.tar.gz", links_dir)
+    download_file(f"{mirror_loong64}core/os/loong64/core.links.tar.gz",
+                  f"{temp_dir.name}/core.links.tar.gz")
+    print(f"core.links.tar.gz has downloaded.")
+    extract_tar_gz(f"{temp_dir.name}/core.links.tar.gz", links_dir)
+
+    download_file(f"{mirror_loong64}extra/os/loong64/extra.links.tar.gz",
+                  f"{temp_dir.name}/extra.links.tar.gz")
+    print(f"extra.links.tar.gz has downloaded.")
+    extract_tar_gz(f"{temp_dir.name}/extra.links.tar.gz", links_dir)
 
     links_libs = scan_directory_for_libs(links_dir, 'links')
     files_libs = scan_directory_for_libs(files_dir, 'files')
-    find_orphan_libs(links_libs, files_libs)
+    pkgs = find_orphan_libs(links_libs, files_libs)
 
+    if args.db:
+        conn = dbinit.get_conn(args.db)
+        try:
+            cursor = conn.cursor()
+            for pkg_name in pkgs:
+                # print(f"pkg_name: {pkg_name}")
+                cursor.execute('''
+                INSERT INTO prebuild_list (name, base, repo, x86_version, loong_version)
+                SELECT name, base, repo, x86_version, loong_version
+                FROM packages
+                WHERE CONCAT(name, '-', x86_version) = %s
+                ON CONFLICT (name) DO NOTHING
+                ''', (pkg_name,))
+            cursor.close()
+            conn.commit()
+        except Exception as e:
+            print(f"Error inserting into database: {e}")
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
 
 if __name__ == "__main__":
     main()

--- a/scripts/compare86.py
+++ b/scripts/compare86.py
@@ -178,6 +178,7 @@ def compare_all():
                 repo=repo
             )
             pkglist.append(p)
+    return pkglist
 
 def show_reverse_depends(depend):
     queue = deque()

--- a/scripts/compare86.py
+++ b/scripts/compare86.py
@@ -19,8 +19,6 @@ cache_dir = os.path.join(home_dir, ".cache", "compare86")
 # Define the repo file paths
 x86_repo_path = "x86"
 loong64_repo_path = "loong"
-mirror_x86 = "https://mirrors.pku.edu.cn/archlinux/"
-mirror_loong64 = "https://loongarchlinux.lcpu.dev/loongarch/archlinux/"
 source_repos = ['core', 'extra']
 
 pkgtime = {}
@@ -60,7 +58,7 @@ def get_builddate():
             pkgtime[pkg.base] = pkg.builddate
 
 
-def update_repo():
+def update_repo(mirror_x86, mirror_loong64):
     for repo in source_repos:
         download_file(f"{mirror_x86}{repo}/os/x86_64/{repo}.db",
                       f"{cache_dir}/{x86_repo_path}/sync/{repo}.db")
@@ -376,8 +374,18 @@ def main():
     parser.add_argument("-d", "--depend", type=str, help="List reverse depends.")
     parser.add_argument("-o", "--output", type=str, help="Save output to file.")
     parser.add_argument( "--db", type=str, help="Save output to database.")
+    parser.add_argument( "--mirror_x86", type=str, help="Mirror of x86.")
+    parser.add_argument( "--mirror_loong", type=str, help="Mirror of loong.")
     
     args = parser.parse_args()
+
+    mirror_x86 = "https://mirrors.pku.edu.cn/archlinux/"
+    mirror_loong64 = "https://loongarchlinux.lcpu.dev/loongarch/archlinux/"
+
+    if args.mirror_x86:
+        mirror_x86 = args.mirror_x86
+    if args.mirror_loong:
+        mirror_loong64 = args.mirror_loong
 
     required_for_output = [
         args.core, args.extra, args.all, args.build
@@ -403,7 +411,7 @@ def main():
     if args.sync:
         if args.stag and args.test:
             source_repos = ["core", "extra", "core-staging", "extra-staging", "core-testing", "extra-testing"]
-        update_repo()
+        update_repo(mirror_x86, mirror_loong64)
 
     if args.build:
         safe_tobuild()

--- a/scripts/dbinit.py
+++ b/scripts/dbinit.py
@@ -24,25 +24,25 @@ def get_conn(config):
     return conn
 
 # Write packages to database
-def create_database(db):
+def create_tables(db):
     conn = get_conn(db)
     cursor = conn.cursor()
     # cursor.execute(f'''DROP TABLE IF EXISTS {compare_method} ''')
     # Create a table for each compare method
-    for method in compare_methods:
-        cursor.execute(f'''
-        CREATE TABLE IF NOT EXISTS {method} (
-        name TEXT PRIMARY KEY,
-        base TEXT,
-        repo TEXT,
-        x86_version TEXT,
-        x86_testing_version TEXT,
-        x86_staging_version TEXT,
-        loong_version TEXT,
-        loong_testing_version TEXT,
-        loong_staging_version TEXT
-        )
-        ''')
+    # for method in compare_methods:
+    #     cursor.execute(f'''
+    #     CREATE TABLE IF NOT EXISTS {method} (
+    #     name TEXT PRIMARY KEY,
+    #     base TEXT,
+    #     repo TEXT,
+    #     x86_version TEXT,
+    #     x86_testing_version TEXT,
+    #     x86_staging_version TEXT,
+    #     loong_version TEXT,
+    #     loong_testing_version TEXT,
+    #     loong_staging_version TEXT
+    #     )
+    #     ''')
 
     cursor.execute(f'''
         CREATE TABLE IF NOT EXISTS packages (
@@ -59,6 +59,28 @@ def create_database(db):
         )
     ''')
 
+    cursor.execute("DROP TABLE IF EXISTS black_list;")
+
+    cursor.execute(f'''
+        CREATE TABLE black_list (
+        name TEXT PRIMARY KEY
+        )
+    ''')
+
+    conn.commit()
+    cursor.close()
+    conn.close()
+
+def load_black_list(db, bl_file):
+    conn = get_conn(db)
+    cursor = conn.cursor()
+    
+    with open(bl_file, 'r') as f:
+        for line in f:
+            name = line.strip()
+            if name:
+                cursor.execute('INSERT INTO black_list (name) VALUES (%s) ON CONFLICT (name) DO NOTHING', (name,))
+    
     conn.commit()
     cursor.close()
     conn.close()
@@ -66,12 +88,15 @@ def create_database(db):
 def main():
     parser = argparse.ArgumentParser(description="Compare packages between x86 and loong.")
     parser.add_argument( "--db", type=str, help="Database name.")
+    parser.add_argument( "--bl", type=str, help="Banned packages")
     args = parser.parse_args()
     
     if args.db is None:
         print("Must provide database name!")
         return
-    create_database(args.db)
-
+    create_tables(args.db)
+    if args.bl:
+        load_black_list(args.db, args.bl)
+        
 if __name__ == "__main__":
     main()

--- a/scripts/dbinit.py
+++ b/scripts/dbinit.py
@@ -175,7 +175,7 @@ def compare_all(cache_dir, x86_repo_path, loong64_repo_path):
             pkglist.append(p)
     return pkglist
 
-def fetch_all_packges(conn):
+def fetch_all_packages(conn):
     home_dir = os.path.expanduser("~")
     cache_dir = os.path.join(home_dir, ".cache", "loongpkgs")
     mirror_x86 = "https://mirrors.pku.edu.cn/archlinux/"
@@ -230,7 +230,7 @@ def main():
         conn.autocommit = False
 
         create_tables(conn)
-        fetch_all_packges(conn)
+        fetch_all_packages(conn)
         if args.bl:
             load_black_list(conn, args.bl)
         conn.commit()

--- a/scripts/dbinit.py
+++ b/scripts/dbinit.py
@@ -36,7 +36,7 @@ def create_tables(db):
         base TEXT,
         repo TEXT,
         error_type TEXT,
-        has_log BOOL,
+        has_log BOOL DEFAULT FALSE,
         is_blacklisted BOOL DEFAULT FALSE,
         x86_version TEXT,
         x86_testing_version TEXT,

--- a/scripts/dbinit.py
+++ b/scripts/dbinit.py
@@ -1,5 +1,7 @@
 import argparse
+import compare86
 import json
+import os
 import psycopg2
 
 compare_methods=['core_pkg', 'extra_pkg', 'all_pkg', 'build_pkg']
@@ -27,35 +29,21 @@ def get_conn(config):
 def create_tables(db):
     conn = get_conn(db)
     cursor = conn.cursor()
-    # cursor.execute(f'''DROP TABLE IF EXISTS {compare_method} ''')
-    # Create a table for each compare method
-    # for method in compare_methods:
-    #     cursor.execute(f'''
-    #     CREATE TABLE IF NOT EXISTS {method} (
-    #     name TEXT PRIMARY KEY,
-    #     base TEXT,
-    #     repo TEXT,
-    #     x86_version TEXT,
-    #     x86_testing_version TEXT,
-    #     x86_staging_version TEXT,
-    #     loong_version TEXT,
-    #     loong_testing_version TEXT,
-    #     loong_staging_version TEXT
-    #     )
-    #     ''')
 
     cursor.execute(f'''
         CREATE TABLE IF NOT EXISTS packages (
-        name TEXT PRIMARY KEY,
+        name TEXT,
         base TEXT,
         repo TEXT,
-        flags INTEGER,
+        error_type TEXT,
+        has_log BOOL,
         x86_version TEXT,
         x86_testing_version TEXT,
         x86_staging_version TEXT,
         loong_version TEXT,
         loong_testing_version TEXT,
-        loong_staging_version TEXT
+        loong_staging_version TEXT,
+        PRIMARY KEY (name, repo)
         )
     ''')
 
@@ -85,6 +73,25 @@ def load_black_list(db, bl_file):
     cursor.close()
     conn.close()
 
+# Fetch all packages from x86 and loong, and insert into database
+def fetch_all_packges(db):
+    pkglist = compare86.compare_all()
+    conn = get_conn(db)
+    
+    cursor = conn.cursor()
+
+    cursor.executemany(f'''
+    INSERT INTO packages (name, base, x86_version, loong_version, repo)
+    VALUES (%s, %s, %s, %s, %s)
+    ON CONFLICT (name, repo) DO UPDATE
+    SET x86_version = EXCLUDED.x86_version,
+        loong_version = EXCLUDED.loong_version
+    ''', [(pkg.name, pkg.base, pkg.x86_version, pkg.loong64_version, pkg.repo) for pkg in pkglist])
+    
+    conn.commit()
+    cursor.close()
+    conn.close()
+
 def main():
     parser = argparse.ArgumentParser(description="Compare packages between x86 and loong.")
     parser.add_argument( "--db", type=str, help="Database name.")
@@ -98,5 +105,7 @@ def main():
     if args.bl:
         load_black_list(args.db, args.bl)
         
+    fetch_all_packges(args.db)
+
 if __name__ == "__main__":
     main()

--- a/scripts/dbinit.py
+++ b/scripts/dbinit.py
@@ -41,7 +41,7 @@ def create_tables(conn):
     cursor.execute("DROP TABLE IF EXISTS build_list;")
 
     cursor.execute(f'''
-        CREATE TABLE IF NOT EXISIS packages (
+        CREATE TABLE IF NOT EXISTS packages (
         name TEXT PRIMARY KEY,
         base TEXT,
         repo TEXT,

--- a/scripts/dbinit.py
+++ b/scripts/dbinit.py
@@ -37,6 +37,7 @@ def create_tables(db):
         repo TEXT,
         error_type TEXT,
         has_log BOOL,
+        is_blacklisted BOOL DEFAULT FALSE,
         x86_version TEXT,
         x86_testing_version TEXT,
         x86_staging_version TEXT,
@@ -69,6 +70,7 @@ def load_black_list(db, bl_file):
             if name:
                 cursor.execute('INSERT INTO black_list (name) VALUES (%s) ON CONFLICT (name) DO NOTHING', (name,))
     
+    cursor.execute("UPDATE packages SET is_blacklisted = TRUE WHERE name IN (SELECT name FROM black_list);")
     conn.commit()
     cursor.close()
     conn.close()
@@ -102,10 +104,9 @@ def main():
         print("Must provide database name!")
         return
     create_tables(args.db)
+    fetch_all_packges(args.db)
     if args.bl:
         load_black_list(args.db, args.bl)
         
-    fetch_all_packges(args.db)
-
 if __name__ == "__main__":
     main()

--- a/scripts/genrebuild
+++ b/scripts/genrebuild
@@ -51,7 +51,7 @@ parser.add_argument('--dbpath', nargs='?', default="/var/lib/pacman",
 # Either packages or a database that contains packages must be provided
 group = parser.add_mutually_exclusive_group()
 group.add_argument('package', nargs='*', help='Packages to rebuild')
-group.add_argument('--pkgdb', nargs=2, metavar=('DB_PATH', 'TABLE_NAME'), help='Packages to rebuild from a database')
+group.add_argument('--pkgdb', nargs=1, help='Packages to rebuild from a database')
 
 args = parser.parse_args()
 
@@ -78,10 +78,9 @@ rebuild_list = set()
 
 if args.pkgdb:
     db = args.pkgdb[0]
-    table = args.pkgdb[1]
     conn = dbinit.get_conn(Path(db))
     cursor = conn.cursor()
-    select_name = f'''SELECT name FROM {table} WHERE x86_version != 'missing'; '''
+    select_name = f'''SELECT name FROM prebuild_list WHERE x86_version != 'missing'; '''
     cursor.execute(select_name)
     
     rebuild_list = {row[0] for row in cursor.fetchall()}
@@ -307,13 +306,11 @@ for pkg in nx.topological_sort(G):
 # Write back to database
 if args.pkgdb:
     db = args.pkgdb[0]
-    table = args.pkgdb[1]
     conn = dbinit.get_conn(Path(db))
     cursor = conn.cursor()
 
     try:
-        get_table_schema = f"""SELECT column_name FROM information_schema.columns WHERE table_name = '{table}' ORDER BY ordinal_position"""
-        print(get_table_schema)
+        get_table_schema = f"""SELECT column_name FROM information_schema.columns WHERE table_name = 'prebuild_list' ORDER BY ordinal_position"""
         cursor.execute(get_table_schema)
         columns = [row[0] for row in cursor.fetchall()]
 
@@ -338,7 +335,7 @@ if args.pkgdb:
         serial = 1
         for pkg in result:
             # Get packages' entry
-            get_package = f"""SELECT * FROM {table} WHERE name = '{pkg}'"""
+            get_package = f"""SELECT * FROM prebuild_list WHERE name = '{pkg}'"""
             cursor.execute(get_package)
             rows = cursor.fetchall()
 

--- a/scripts/github-issue-hook.py
+++ b/scripts/github-issue-hook.py
@@ -1,0 +1,59 @@
+import argparse
+import dbinit
+from github import Github
+
+def main():
+    parser = argparse.ArgumentParser(description='Auto issue creation for build errors')
+    parser.add_argument('--db', nargs=2, metavar=('DATABASE', 'TABLE'), required=True,
+                       help='Database path')
+    parser.add_argument('-t', '--token',  required=True,
+                       help='Github token')
+    parser.add_argument('-r', '--repo', required=True,
+                       help='Github repo')
+    args = parser.parse_args()
+
+    try:
+        # Connect to database
+        conn = dbinit.get_conn(args.db[0])
+        cursor = conn.cursor()
+        print(f"Connected to database: {args.db[0]}")
+        query = f"SELECT name, base, repo, status, x86_version, loong_version FROM {args.db[1]} WHERE status != 'Pending' AND status != 'Success' AND status != 'Building'"
+        cursor.execute(query)
+        records = cursor.fetchall()
+
+        # Connect to GitHub repo
+        g = Github(args.token)
+        github_repo = g.get_repo(args.repo)
+
+        # Create issues for each record
+        for record in records:
+            name, base, repo, status, x86_version, loong_version = record
+            
+            body = f"""
+## Details  
+{base}/{name} in {repo}
+- X86 version：{x86_version}
+- Current Loong version：{loong_version}
+
+## Error Type  
+```error
+{status}
+```  
+
+See more details in the [build log](https://loongarchlinux.lcpu.dev/log?base={base}&name={name}&version={x86_version}).
+"""
+            
+            issue = github_repo.create_issue(
+                title=f"[Bot] {base}/{name} {loong_version} -> {x86_version} failed to build",
+                body=body.strip(),
+                labels=["build-error", "automated"]
+            )
+
+    except Exception as e:
+        print(f"Failed to create issue: {str(e)}")
+    finally:
+        if 'conn' in locals():
+            conn.close()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] feat    <!-- 引入新功能 | Introduce new features -->
 - Package data preloading
 - Mirror designation
 - Include checksoname rebuilds
 - Remove correctly built packages from blacklist automaically
 - Task handler
- [x] fix    <!-- 修复 Bug | Fix a bug -->
 - Vulnerable database actions
 - GPG signing

#### 📝Additional Information
#15 is based on #14 

I removed '-t' option for `ssh` command in `1build.sh`and I suspect failures for some builds, but it allows task handler to manipulate tasks conveniently.

Question may ask: 
What is Task handler

Ans:
Basically I think many(?) building tasks will stuck for many reasons and stuck the whole building process since there is no timeout mechanism, and there is currently no way to either skip or retry the build except quitting the whole workflow. So I coded this simple task handler providing those actions.

For some reasons the task handler does not work well with the '-t' option on, so I removed it. But anyway I don't think this is a smart move.